### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/tdevere/ad92d5db-1e8c-4fd3-b00d-628cac772c10/5947d5e5-4af6-43ce-be47-6be4e585cb06/_apis/work/boardbadge/634e98fd-e819-4f02-b922-64297e4217ec)](https://dev.azure.com/tdevere/ad92d5db-1e8c-4fd3-b00d-628cac772c10/_boards/board/t/5947d5e5-4af6-43ce-be47-6be4e585cb06/Microsoft.RequirementCategory)
 # Android_Xamarin
 Android_Xamarin


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#138](https://dev.azure.com/tdevere/ad92d5db-1e8c-4fd3-b00d-628cac772c10/_workitems/edit/138). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.